### PR TITLE
fix gulp-include v2.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "gulp-clean-css": "^3.2.0",
     "gulp-concat": "^2.6.0",
     "gulp-copy": "^1.0.0",
-    "gulp-include": "^2.3.1",
+    "gulp-include": "~2.3.1",
     "gulp-plumber": "^1.1.0",
     "gulp-sass": "^3.1.0",
     "gulp-sourcemaps": "^2.6.0",


### PR DESCRIPTION
Fix 12298 npm install
Forcing version 2.3.1 gulp-include